### PR TITLE
update for Express 4.x (Session is a standalone module now)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,21 +19,25 @@
       * Module dependencies.
       */
 
-      var express = require('express');
+      var express = require('express')
+        , session = require('express-session')
+        , favicon = require('serve-favicon')
+        , logger = require('morgan')
+        , cookieParser = require('cookie-parser')
+        , http = require('http')
+        , app = express();
 
       // pass the express to the connect memcached module
       // allowing it to inherit from express.session.Store
-      var MemcachedStore = require('connect-memjs')(express);
+      var MemcachedStore = require('connect-memjs')(session);
 
-      var app = express.createServer();
-
-      app.use(express.favicon());
+      app.use(favicon());
 
       // request logging
-      app.use(express.logger());
+      app.use(logger());
 
       // required to parse the session cookie
-      app.use(express.cookieParser());
+      app.use(cookieParser());
 
       // Populates:
       // - req.session
@@ -41,7 +45,7 @@
       // - req.sessionID (or req.session.id)
 
       var store = new MemcachedStore({servers: ['127.0.0.1:1121'], username: 'liam', password: 'hunter2'});
-      app.use(express.session({ 
+      app.use(session({ 
         secret: 'CatOnTheKeyboard', 
         store:  
       }));
@@ -55,8 +59,9 @@
         res.send('Viewed <strong>' + req.session.views + '</strong> times.');
       });
 
-      app.listen(3000);
-      console.log('Express app started on port 3000');
+      http.createServer(app).listen(3000, function(){
+        console.log('Express app started on port 3000');
+      });
 
 ## Options
 

--- a/lib/connect-memjs.js
+++ b/lib/connect-memjs.js
@@ -8,7 +8,7 @@
  * Library version.
  */
 
-exports.version = '0.0.7';
+exports.version = '0.0.8';
 
 
 /**
@@ -32,13 +32,13 @@ var oneDay = 86400;
  * @api public
  */
 
-module.exports = function(connect){
+module.exports = function(session){
 
   /**
    * Connect's Store.
    */
 
-  var Store = connect.session.Store;
+  var Store = session.Store;
 
   /**
    * Initialize MemcachedStore with the given `options`.


### PR DESCRIPTION
Only real change is connect.session.Store which is now session.Store. In Express 4, session is not core of Express but is a Standalone module.

Readme has been updated to better suit Express 4.
