### PR TITLE
allow to use memcached client provided by user

### DIFF
--- a/lib/connect-memjs.js
+++ b/lib/connect-memjs.js
@@ -53,19 +53,23 @@ module.exports = function(session){
     options = options || {};
     Store.call(this, options);
 
-    var servers = null;
-    if (options.servers) {
-      servers = options.servers.join(',');
+    if (!options.client) {
+      var servers = null;
+      if (options.servers) {
+        servers = options.servers.join(',');
+      }
+
+      this.debug = options.debug || false;
+
+      if (options.prefix) {
+          this.prefix = options.prefix;
+      }
+
+      options.client = memjs.Client.create(servers, options);
+      log("memjs initialized for servers: " + servers);
     }
 
-    this.debug = options.debug || false;
-
-    if (options.prefix) {
-        this.prefix = options.prefix;
-    }
-
-    this.client = new memjs.Client.create(servers, options)
-    log("memjs initialized for servers: " + servers);
+    this.client = options.client;
 
     //this.client.on("issue", function(issue) {
     //    log("memjs::Issue @ " + issue.server + ": " + 


### PR DESCRIPTION
1. Allow users to use the memcached client defined by themselves.
2. bugfix: When use memjs.Client.create() method, don't need to instantiate a new client. it is already done in memjs module