### PR TITLE
Correcting the error handling

### DIFF
--- a/lib/connect-memjs.js
+++ b/lib/connect-memjs.js
@@ -151,17 +151,13 @@ module.exports = function(session){
   MemcachedStore.prototype.set = function(sid, sess, fn) {
       sid = this.getKey(sid);
 
-      try {
-          var maxAge = sess.cookie.maxAge
-          var ttl = 'number' == typeof maxAge ? maxAge / 1000 | 0 : oneDay
-          var sess = JSON.stringify(sess);
+      var maxAge = sess.cookie.maxAge
+      var ttl = 'number' == typeof maxAge ? maxAge / 1000 | 0 : oneDay
+      var sess = JSON.stringify(sess);
 
-          this.client.set(sid, sess, function() {
-              fn && fn.apply(this, arguments);
-          }, ttl);
-      } catch (err) {
-          fn && fn(err);
-      } 
+      this.client.set(sid, sess, function() {
+          fn && fn.apply(this, arguments);
+      }, ttl);
   };
 
   /**

--- a/lib/connect-memjs.js
+++ b/lib/connect-memjs.js
@@ -15,6 +15,7 @@ exports.version = '0.0.8';
  * Module dependencies.
  */
 
+var debug = require('debug')('connect-memjs');
 var memjs = require('memjs');
 
 /**
@@ -116,22 +117,25 @@ module.exports = function(session){
 
       var that = this;
       this.client.get(sid, function(err, data) {
+          if (err) {
+              debug('Session GET failed:', err);
+              return fn(err);
+          }
+          if (!data)
+              return fn();
+
           try {
-              if (!data) {
-                 return fn();
-              }
-              fn(null, JSON.parse(data.toString()));
-              if (that.debug) {
-                var totalTime = (new Date().getTime()) - startTime;
-                console.log("Session GET took " + totalTime + 'ms');
-              }
-          } catch (err) {
-              if (that.debug) {
-                console.log("Session GET failed:");
-                console.log(err);
-              }
-              fn(err);
-          } 
+              data = JSON.parse(data);
+          }
+          catch (e) {
+              debug('parsing session data failed, setting null');
+              data = null;
+          }
+          if (that.debug) {
+              var totalTime = (new Date().getTime()) - startTime;
+              debug("Session GET took " + totalTime + 'ms');
+          }
+          fn(null, data);
       });
   };
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,34 @@
 {
-    "name": "connect-memjs"
-  , "version": "0.1.0"
-  , "description": "Memcached session store for Connect backed by memjs"
-  , "keywords": ["memcached", "connection", "session", "store", "cache"]
-  , "author": "Michał Thoma <michal@balor.pl>"
-  , "contributors": [
+  "name": "connect-memjs",
+  "version": "0.1.0",
+  "description": "Memcached session store for Connect backed by memjs",
+  "keywords": [
+    "memcached",
+    "connection",
+    "session",
+    "store",
+    "cache"
+  ],
+  "author": "Michał Thoma <michal@balor.pl>",
+  "contributors": [
     "Liam Don <liamdon@gmail.com>"
-  ]
-  , "repository": {
+  ],
+  "repository": {
     "type": "git",
     "url": "https://github.com/liamdon/connect-memjs"
+  },
+  "dependencies": {
+    "debug": "^2.6.3",
+    "memjs": ">= 0.9.0"
+  },
+  "devDependencies": {
+    "connect": ">= 1.4.x"
+  },
+  "main": "index",
+  "engines": {
+    "node": ">=0.4.7"
+  },
+  "directories": {
+    "lib": "./lib"
   }
-  , "dependencies": { "memjs": ">= 0.9.0" }
-  , "devDependencies": { "connect": ">= 1.4.x" }
-  , "main": "index"
-  , "engines": { "node": ">=0.4.7" }
-  , "directories": { "lib": "./lib" }
 }


### PR DESCRIPTION
I corrected the error handling in the usages of the client.get and client.set methods of the memcache store.  The try/catch being used wasn't actually handling any errors passed to the callback by memjs.

I also added the debug module, in order to log things without needing to use the options.debug flag.  That can be removed if you think it dirties this PR -- npm changed a bunch of your package.json formatting, sorry.